### PR TITLE
Fix nuke crash on script clear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ---- ignore special files written during config setup
+tk-metadata
+
+# Byte-compiled / optimized / DLL files
 *.py[cod]
 
 # C extensions

--- a/hooks/scene_operation_tk-nuke.py
+++ b/hooks/scene_operation_tk-nuke.py
@@ -91,8 +91,10 @@ class SceneOperation(Hook):
             # open the specified script into the current window
             if nuke.root().modified():
                 raise TankError("Script is modified!")
-            nuke.scriptClear()
-            nuke.scriptOpen(file_path)
+            # See shotgunsoftware/tk-multi-snapshot/pull/23
+            for node in nuke.allNodes():
+                nuke.delete(node)
+            nuke.scriptReadFile(file_path)
         elif operation == "save":
             # save the current script:
             nuke.scriptSave()


### PR DESCRIPTION
Use an alternate "open in place" logic provided by the Foundry to work around `nuke.scriptClear()` crashing Nuke after submitting render to Deadline.

From Foundry support ticket 50513, Reference `46a9edc2-4f3c-4f4d-64ecca43-2a030103`

See https://github.com/shotgunsoftware/tk-multi-snapshot/pull/23

To be released as `v0.7.4+wwfx.1.0.0`